### PR TITLE
Shell script to sync to latest vendor version

### DIFF
--- a/update_from_vendor.sh
+++ b/update_from_vendor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Checkout vendor repo
-echo "Cloning vendor repo into tmp_vendor"
+echo "Cloning nostalgiaz/bootstrap-switch github repo into tmp_vendor"
 git clone https://github.com/nostalgiaz/bootstrap-switch.git tmp_vendor
 
 # Copy files


### PR DESCRIPTION
Adds a shell script that will temporarily clone the vendored [bootstrap-switch](https://github.com/nostalgiaz/bootstrap-switch) and copy over the latest javascript and css files for you. Should make keeping this gem in sync with the latest release fairly painless in the future.
